### PR TITLE
Load jQuery and Bootstrap from a CDN

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,6 @@ const uglify = require('gulp-uglify');
 const clean = require('gulp-clean');
 const concat = require('gulp-concat');
 const cleanCSS = require('gulp-clean-css');
-const merge = require('merge-stream');
 
 // --- Tasks
 // - Default task. Will start dev server, watch for changes, and build them on the fly
@@ -17,30 +16,21 @@ gulp.task('default', ['build']);
 
 // - Copy js to build dir, minify/uglify app code
 gulp.task('build-js', () => {
-    var jquery = gulp.src('node_modules/jquery/dist/jquery.min.js')
-        .pipe(gulp.dest(buildDir+'/js'));
-
-    var bootstrap = gulp.src('node_modules/bootstrap/dist/js/bootstrap.min.js')
-        .pipe(gulp.dest(buildDir+'/js'));
-
     var app = gulp.src('src/js/**/*.js')
         .pipe(concat('main.js'))
         .pipe(uglify())
-        .pipe(gulp.dest(buildDir+'/js'));
+        .pipe(gulp.dest(buildDir + '/js'));
 
-    return merge(jquery, bootstrap, app);
+    return app;
 });
 
 // - Bundle CSS
 gulp.task('build-css', () => {
-    var bootstrap = gulp.src('node_modules/bootstrap/dist/css/bootstrap.min.css')
-        .pipe(gulp.dest(buildDir+'/css'));
-
     var app = gulp.src('src/css/**/*.css')
         .pipe(cleanCSS())
-        .pipe(gulp.dest(buildDir+'/css'));
+        .pipe(gulp.dest(buildDir + '/css'));
 
-    return merge(bootstrap, app);
+    return app;
 });
 
 // - Copy HTML & PHP
@@ -54,8 +44,7 @@ gulp.task('copy-pages', () => {
 
 // - Clean build directory
 gulp.task('clean', () => {
-    return gulp.src(buildDir+'/*')
-        .pipe(clean());
+    return gulp.src(buildDir + '/*').pipe(clean());
 });
 
 // - Build entire project

--- a/package.json
+++ b/package.json
@@ -18,16 +18,11 @@
     "url": "https://github.com/widd/kitsune-register/issues"
   },
   "homepage": "https://github.com/widd/kitsune-register#readme",
-  "dependencies": {
-    "bootstrap": "^3.3.6",
-    "jquery": "^3.1.0"
-  },
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-clean-css": "^2.0.12",
     "gulp-concat": "^2.6.0",
-    "gulp-uglify": "^2.0.0",
-    "merge-stream": "^1.0.0"
+    "gulp-uglify": "^2.0.0"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
 
     <title>Kitsune Registration</title>
 
-    <link href="css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
     <link href="css/main.css" rel="stylesheet">
 
     <!--[if lt IE 9]>
@@ -51,9 +51,8 @@
 </form>
 </body>
 
-<script type="text/javascript" src="js/jquery.min.js"></script>
-<script type="text/javascript" src="js/bootstrap.min.js"></script>
-<!-- Over a secure connection, please. -->
+<script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
+<script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://google.com/recaptcha/api.js"></script>
 <script type="text/javascript" src="js/main.js"></script>
 


### PR DESCRIPTION
I propose that jQuery and Bootstrap be loaded from a CDN, since code.google.com and bootstrapcdn.com are used very often for sites in production, thereby reducing latency by providing clients with copies that one can reasonably assume has already been cached. This also reduces the amount of work that NPM and Gulp must do, both reducing the amount of dependencies, and requiring fewer operations from Gulp.